### PR TITLE
Caption settings return to menu

### DIFF
--- a/src/js/control-bar/text-track-controls/subs-caps-button.js
+++ b/src/js/control-bar/text-track-controls/subs-caps-button.js
@@ -59,6 +59,12 @@ class SubsCapsButton extends TextTrackButton {
     return items;
   }
 
+  /**
+   * Re-open the caption list after modal close to promote accessibility
+   */
+  reopenCaptionListAfterModalClose() {
+    this.pressButton();
+  }
 }
 
 /**

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -601,6 +601,14 @@ class TextTrackSettings extends ModalDialog {
     }
   }
 
+  /**
+   * Re-open the menu that triggered the modal to increase accessibility
+   */
+  close() {
+    super.close();
+    this.player().getChild('ControlBar').getChild('subsCapsButton').reopenCaptionListAfterModalClose();
+  }
+
 }
 
 Component.registerComponent('TextTrackSettings', TextTrackSettings);

--- a/test/unit/tracks/text-track-settings.test.js
+++ b/test/unit/tracks/text-track-settings.test.js
@@ -231,7 +231,7 @@ QUnit.test('should open on click', function(assert) {
   clock.restore();
 });
 
-QUnit.test('should close on done click', function(assert) {
+QUnit.test('should close and re-open menu on done click', function(assert) {
   const clock = sinon.useFakeTimers();
   const player = TestHelpers.makePlayer({
     tracks
@@ -242,6 +242,7 @@ QUnit.test('should close on done click', function(assert) {
   Events.trigger(player.$('.vjs-texttrack-settings'), 'click');
   Events.trigger(player.$('.vjs-done-button'), 'click');
   assert.ok(player.textTrackSettings.hasClass('vjs-hidden'), 'settings closed');
+  assert.ok(player.controlBar.subsCapsButton.menu.hasClass('vjs-lock-showing'), 'captions menu reopened');
 
   player.dispose();
   clock.restore();


### PR DESCRIPTION
## Description
During an accessibility audit of a project I work on that uses VideoJS we received the following feedback about how the focus is handled after closing the Caption Settings menu.

> Users will expect to be returned to the item that activated the dialog when they close the dialog.
> When a user closes the dialog, focus should be moved back to the menu item for "caption settings".
> Keyboard focus does not return to the control which opened the dialog when it is closed.

Fixes [#6949](https://github.com/videojs/video.js/issues/6949)

## Specific Changes proposed
When the TextTrackSettings modal is closed, the SubsCapsButton will be re-selected, and the captions menu list will be re-opened. 

To build the changes locally, run `npm install`, `npm start`, then navigate to `open http://localhost:9999/sandbox/index.html`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [x] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors

